### PR TITLE
Improve examples of how to fire process errors

### DIFF
--- a/examples/errors.js
+++ b/examples/errors.js
@@ -7,10 +7,7 @@ const { emitWarning } = require('process')
 // Emit an `uncaughtException` event
 const uncaughtException = function() {
   setTimeout(() => {
-    // eslint-disable-next-line max-nested-callbacks
-    setTimeout(() => {
-      throw new Error('File not found')
-    }, 0)
+    throw new Error('File not found')
   }, 0)
 }
 
@@ -18,8 +15,8 @@ const uncaughtException = function() {
 const unhandledRejection = function() {
   const promise = Promise.reject(new Error('Invalid permission'))
   setTimeout(() => {
-    // eslint-disable-next-line no-empty-function, max-nested-callbacks
-    promise.catch(() => {})
+    // eslint-disable-next-line max-nested-callbacks
+    promise.catch(() => ({}))
   }, 0)
 }
 
@@ -34,8 +31,8 @@ const warning = function() {
 
 // Emit a `multipleResolves` event
 const multipleResolves = function() {
-  // eslint-disable-next-line no-new, promise/avoid-new
-  new Promise((resolve, reject) => {
+  // eslint-disable-next-line promise/avoid-new
+  return new Promise((resolve, reject) => {
     resolve({ success: true })
     reject(new Error('Cannot send request'))
   })

--- a/examples/errors.js
+++ b/examples/errors.js
@@ -15,8 +15,8 @@ const uncaughtException = function() {
 const unhandledRejection = function() {
   const promise = Promise.reject(new Error('Invalid permission'))
   setTimeout(() => {
-    // eslint-disable-next-line max-nested-callbacks
-    promise.catch(() => ({}))
+    // eslint-disable-next-line no-empty-function, max-nested-callbacks
+    promise.catch(() => {})
   }, 0)
 }
 


### PR DESCRIPTION
I am reading your source code(read an example first) and I have a question:

Why you call `setTimeout` inside `setTimeout`? Are we need it?

This commit remove some `eslint-disable` rules.


- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests (we are enforcing 100% test coverage).
- [ ] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
