### PR TITLE
Use `eslint-env` instead of  disable `no-undef`

### DIFF
--- a/test/helpers/testing/jasmine/main.js
+++ b/test/helpers/testing/jasmine/main.js
@@ -1,11 +1,10 @@
+//* eslint-env jasmine */
 import { EVENTS } from '../../emit/main.js'
 import { getOptions } from '../options.js'
 
 const { name } = getOptions()
 
-// eslint-disable-next-line no-undef
 describe('should make tests fail', () => {
-  // eslint-disable-next-line no-undef
   it(`on ${name}`, () => {
     // eslint-disable-next-line no-empty-function, max-nested-callbacks
     EVENTS[name]().catch(() => {})

--- a/test/helpers/testing/jasmine/main.js
+++ b/test/helpers/testing/jasmine/main.js
@@ -1,4 +1,4 @@
-//* eslint-env jasmine */
+/* eslint-env jasmine */
 import { EVENTS } from '../../emit/main.js'
 import { getOptions } from '../options.js'
 

--- a/test/helpers/testing/mocha/main.js
+++ b/test/helpers/testing/mocha/main.js
@@ -1,4 +1,4 @@
-//* eslint-env mocha */
+/* eslint-env mocha */
 import { EVENTS } from '../../emit/main.js'
 import { getOptions } from '../options.js'
 

--- a/test/helpers/testing/mocha/main.js
+++ b/test/helpers/testing/mocha/main.js
@@ -1,11 +1,10 @@
+//* eslint-env mocha */
 import { EVENTS } from '../../emit/main.js'
 import { getOptions } from '../options.js'
 
 const { name } = getOptions()
 
-// eslint-disable-next-line no-undef
 describe('should make tests fail', function testSuite() {
-  // eslint-disable-next-line no-undef
   it(`on ${name}`, () => {
     // eslint-disable-next-line no-empty-function, max-nested-callbacks
     EVENTS[name]().catch(() => {})


### PR DESCRIPTION
Use `eslint-env` is better than `global` or disable `no-undef` when you use `mocha` or `jasmine`

I use: `//* eslint-env jasmine */` instead of `/* eslint-env jasmine */` to bypass `eslint-comments/no-use`