### PR TITLE
Move `func` to first `args`

### DIFF
--- a/test/helpers/data_driven/main.js
+++ b/test/helpers/data_driven/main.js
@@ -11,8 +11,7 @@ import { cartesianProduct } from './utils.js'
 //  - check other data-driven test libraries for features
 //  - allow values to be generating functions
 export const repeat = function(...args) {
-  const arrays = args.slice(0, -1)
-  const func = args[args.length - 1]
+  const [func, ...arrays] = args
 
   const arraysA = cartesianProduct(...arrays)
 

--- a/test/helpers/repeat.js
+++ b/test/helpers/repeat.js
@@ -21,7 +21,8 @@ const isNormalLevel = function(level) {
 
 const NORMAL_LEVELS = LEVELS.filter(isNormalLevel)
 
-export const repeatEvents = repeat.bind(null, getEvents())
-export const repeatLevels = repeat.bind(null, NORMAL_LEVELS)
-export const repeatEventsLevels = repeat.bind(null, getEvents(), NORMAL_LEVELS)
-export const repeatEventsRunners = repeat.bind(null, RUNNERS, getEvents())
+export const repeatEvents = func => repeat(func, getEvents())
+export const repeatLevels = func => repeat(func, NORMAL_LEVELS)
+export const repeatEventsLevels = func =>
+  repeat(func, getEvents(), NORMAL_LEVELS)
+export const repeatEventsRunners = func => repeat(func, RUNNERS, getEvents())


### PR DESCRIPTION
Add function to first and other arguments it better than function in the end:
 - Easy to get `func` and rest arguments
 - Don't break if you run `repeatEventsLevels(oneFunc, 'not function')`
 - It is nature: `repeatEventsLevels(func, arg1, arg2)` same `func(arg1, arg2)`

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests (we are enforcing 100% test coverage).
- [ ] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [ ] The status checks are successful (continuous integration). Those can be
      seen below.

